### PR TITLE
fix: Vision Proニュースが欠落しやすい問題を修正

### DIFF
--- a/scripts/fetch_news.py
+++ b/scripts/fetch_news.py
@@ -33,6 +33,7 @@ IOS_SOURCES = [
     {"url": "https://www.hackingwithswift.com/articles/rss",  "name": "HackingWithSwift"},
     {"url": "https://www.swiftbysundell.com/feed.rss",        "name": "SwiftBySundell"},
     {"url": "https://9to5mac.com/feed/",                      "name": "9to5Mac"},
+    {"url": "https://feeds.macrumors.com/MacRumors-All",      "name": "MacRumors"},
 ]
 
 IOS_KEYWORDS = ["iOS", "Swift", "SwiftUI", "Xcode", "App Store", "iPhone", "UIKit"]
@@ -230,10 +231,12 @@ def write_daily(now: datetime) -> None:
     # 2. iOSエントリ = iOS専用RSS ＋ 全ソースのキーワードフィルタ
     ios_from_sources = collect_ios_entries(hours=24)
     ios_from_keywords = filter_by_keywords(collect_all_entries(hours=24), IOS_KEYWORDS)
-    ios_entries = deduplicate(ios_from_sources + ios_from_keywords)[:15]
+    all_ios = deduplicate(ios_from_sources + ios_from_keywords)
+    ios_entries = all_ios[:15]
 
-    # 3. Vision Proエントリ = 全ソース（general + ios）のキーワードフィルタ
-    vp_entries = filter_by_keywords(general + ios_entries, VISIONPRO_KEYWORDS)[:10]
+    # 3. Vision Proエントリ = 全ソース（general + ios全件）のキーワードフィルタ
+    # ios_entriesのスライス前（all_ios）を使うことで、15件の制限に引っかかったVision Pro記事を拾う
+    vp_entries = filter_by_keywords(general + all_ios, VISIONPRO_KEYWORDS)[:10]
 
     title = f"{date_label} ITニュースランキング"
     content = build_daily_md(general, ios_entries, vp_entries, title, date_iso)


### PR DESCRIPTION
- ios_entries[:15]スライス後にVision Proフィルタをかけていたため、
  15件目以降のVision Pro記事が取得できていなかった。
  スライス前のall_iosを使うよう修正。
- MacRumorsをIOS_SOURCESに追加し、Vision Pro関連記事のカバレッジを向上。

https://claude.ai/code/session_01TQxUnKKriyy74ZNQDPzPt1